### PR TITLE
chore: hardcode version in package.json 3.0.1 for manual publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-admin-bar",
-  "version": "0.0.0-development",
+  "version": "3.0.1",
   "description": "An admin bar",
   "homepage": "https://github.com/economist-components/component-admin-bar",
   "bugs": {


### PR DESCRIPTION
Setting the package version manually to force publish